### PR TITLE
Ignore the `agent-config.yaml` generated by ib-orchestrate-vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /terraform/*/vsphere-vars.tf
 /terraform/*/.terraform*lock*
 /terraform/*/terraform.tfstate*
+/agent-config.yaml


### PR DESCRIPTION
The ib-orchestrate-vm generates an `agent-config.yaml` file and places
it inside this repo's directory (this repo is included as a submodule in
ib-orchestrate-vm).

It would be nice if the `.gitignore` of this repo would ignore this file
so it doesn't count as a change in the submodule