### PR TITLE
Simplify network creaton - No host info needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,14 +133,10 @@ $(INSTALL_CONFIG): $(INSTALL_CONFIG_TEMPLATE) checkenv $(SSH_KEY_PUB_PATH)
 $(NET_CONFIG): $(NET_CONFIG_TEMPLATE)
 	sed -e 's/REPLACE_NET_NAME/$(NET_NAME)/' \
 	    -e 's|REPLACE_NET_UUID|$(NET_UUID)|' \
-	    -e 's|CLUSTER_NAME|$(CLUSTER_NAME)|' \
-	    -e 's|BASE_DOMAIN|$(BASE_DOMAIN)|' \
-	    -e 's/REPLACE_HOST_NAME/$(VM_NAME)/' \
-	    -e 's/REPLACE_HOST_MAC/$(HOST_MAC)/' \
-	    -e 's/REPLACE_HOST_IP/$(HOST_IP)/' \
 	    -e 's/REPLACE_NET_BRIDGE_NAME/$(NET_BRIDGE_NAME)/' \
 	    -e 's/REPLACE_NET_MAC/$(NET_MAC)/' \
 	    -e 's/REPLACE_NET_PREFIX/$(NET_PREFIX)/g' \
+	    -e 's|BASE_DOMAIN|$(BASE_DOMAIN)|' \
 	    $(NET_CONFIG_TEMPLATE) > $@
 
 network: $(NET_CONFIG)
@@ -163,7 +159,7 @@ $(INSTALL_CONFIG_IN_WORKDIR): $(INSTALLER_WORKDIR) $(INSTALL_CONFIG)
 	cp $(INSTALL_CONFIG) $@
 
 # Original CoreOS ISO
-$(INSTALLER_ISO_PATH): 
+$(INSTALLER_ISO_PATH):
 	$(SNO_DIR)/download_live_iso.sh $@
 
 # Get the openshift-installer from the release image

--- a/net.xml.template
+++ b/net.xml.template
@@ -5,20 +5,11 @@
   <bridge name='REPLACE_NET_BRIDGE_NAME' stp='on' delay='0'/>
   <mtu size='1500'/>
   <mac address='REPLACE_NET_MAC'/>
-  <domain name='CLUSTER_NAME.BASE_DOMAIN' localOnly='yes'/>
-  <dns enable='yes'>
-    <host ip='REPLACE_HOST_IP'>
-      <hostname>api.CLUSTER_NAME.BASE_DOMAIN</hostname>
-      <hostname>api-int.CLUSTER_NAME.BASE_DOMAIN</hostname>
-      <hostname>console-openshift-console.apps.CLUSTER_NAME.BASE_DOMAIN</hostname>
-      <hostname>oauth-openshift.apps.CLUSTER_NAME.BASE_DOMAIN</hostname>
-      <hostname>canary-openshift-ingress-canary.apps.CLUSTER_NAME.BASE_DOMAIN</hostname>
-    </host>
-  </dns>
+  <domain name='BASE_DOMAIN' localOnly='yes'/>
+  <dns enable='yes'/>
   <ip family='ipv4' address='REPLACE_NET_PREFIX.1' prefix='24'>
     <dhcp>
       <range start='REPLACE_NET_PREFIX.2' end='REPLACE_NET_PREFIX.254'/>
-      <host mac='REPLACE_HOST_MAC' name='REPLACE_HOST_NAME' ip='REPLACE_HOST_IP'/>
     </dhcp>
   </ip>
 </network>


### PR DESCRIPTION
Since we now provide host information via `host-net-config.sh` script when creating a new VM, it is not needed that host info is provided when creating a network

This minimizes the amount of data needed for network creation