### PR TITLE
Add new `abi-wait-complete` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,11 @@ start-iso-abi: $(ABI_ISO_PATH_IN_LIBVIRT) network destroy-libvirt-sno host-net-c
 	RAM_MB=$(RAM_MB) \
 	$(SNO_DIR)/virt-install-sno-iso-ign.sh
 
+abi-wait-complete: $(INSTALLER_BIN)
+	INSTALLER_BIN=$(INSTALLER_BIN) \
+	INSTALLER_WORKDIR=$(INSTALLER_WORKDIR) \
+	$(SNO_DIR)/wait-abi-complete.sh
+
 # Configure dhcp and dns for host
 .PHONY: host-net-config
 host-net-config:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Automatic mode using Makefiles, currently supports SNO deployments on two virtua
     - Execute the openshift-installer `agent create image` command to generate the agent.iso.
     - Create a libvirt network & VM.
     - Boot the VM with that ISO.
-- You can now monitor the progress using `make ssh` and `journalctl -f -u assisted-service.service` or `kubectl --kubeconfig ./sno-workdir/auth/kubeconfig get clusterversion`.
+- You can now monitor the progress using `abi-wait-complete` or `make ssh` and `journalctl -f -u assisted-service.service` or `kubectl --kubeconfig ./sno-workdir/auth/kubeconfig get clusterversion`.
 
 # Other notes
 

--- a/wait-abi-complete.sh
+++ b/wait-abi-complete.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+if [ -z ${INSTALLER_BIN+x} ]; then
+	echo "Please set INSTALLER_BIN"
+	exit 1
+fi
+
+if [ -z ${INSTALLER_WORKDIR+x} ]; then
+	echo "Please set INSTALLER_WORKDIR"
+	exit 1
+fi
+
+${INSTALLER_BIN} agent wait-for install-complete --dir="${INSTALLER_WORKDIR}"
+
+# TODO: For now this is needed to ensure our kubeconfig gets all the ingress
+# certificates that are created late (these kubeconfig certificates are
+# required for conformance using that kubeconfig to pass). Remove once the ABI
+# ticket AGENT-916 is fixed in all versions we use such that the above agent
+# command will ensure this instead
+${INSTALLER_BIN} wait-for install-complete --dir="${INSTALLER_WORKDIR}"


### PR DESCRIPTION
# Background

The `start-iso-abi` target starts the ABI installation, but it does not wait for the installation to complete. Currently the `ib-orchestrate-vm` repo that uses this repo as a submodule implements its own waiting for installation to complete logic, which includes running `oc` commands and looking at the `clusterversion` resource.

# Issue / Solution

This repo should provide a target that waits for the installation to complete, and it should do it correctly. The openshift-installer `wait-for` commands do more than just wait, they also populate the admin `kubeconfig` that is generated with additional ingress certificates that are created in late stages of cluster finalization. Without them, running conformance tests using said `kubeconfig` will fail as some tests assume the presence of these ingress certificates.

# Implementation

Add a new `abi-wait-complete` target that uses the openshift-installer `wait-for` command to wait for the installation to complete. This target should be run after the `start-iso-abi` target, and the `ib-orchestrate-vm` repo will be updated to use this new target instead of (or on top of) its own logic.

Note that currently, to overcome the AGENT-916 issue, we also run the `wait-for install-complete` command without the `agent` subcommand. This is a temporary workaround until AGENT-916 is fixed in all versions we use.