### PR TITLE
MGMT-21493: Enable ABI with DS primary v4 / v6 and single-stack v6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ ifndef PULL_SECRET
 	$(error PULL_SECRET must be defined)
 endif
 
+IP_STACK ?= v4
+
 INSTALLATION_DISK ?= /dev/vda
 RELEASE_VERSION ?= 4.13.5
 RELEASE_ARCH ?= x86_64
@@ -33,15 +35,21 @@ INSTALLER_ISO_PATH_SNO = $(SNO_DIR)/installer-SNO-image.iso
 INSTALLER_ISO_PATH_SNO_IN_LIBVIRT = $(LIBVIRT_ISO_PATH)/installer-SNO-image.iso
 LIBVIRT_GRAPHICS ?= vnc
 
-MACHINE_NETWORK ?= 192.168.126.0/24
-CLUSTER_NETWORK ?= 10.128.0.0/14
-CLUSTER_SVC_NETWORK ?= 172.30.0.0/16
+MACHINE_NETWORK_V4 ?= $(if $(MACHINE_NETWORK),$(MACHINE_NETWORK),192.168.126.0/24)
+MACHINE_NETWORK_V6 ?= fd00:0:0:126::/64
+CLUSTER_NETWORK_V4 ?= 10.128.0.0/14
+CLUSTER_NETWORK_V6 ?= fd01:0:0:0::/48
+CLUSTER_SVC_NETWORK_V4 ?= 172.30.0.0/16
+CLUSTER_SVC_NETWORK_V6 ?= fd02:0:0:0::/112
+CLUSTER_NETWORK_HOSTPREFIX_V4 ?= 23
+CLUSTER_NETWORK_HOSTPREFIX_V6 ?= 64
 CLUSTER_NAME ?= test-cluster
 BASE_DOMAIN ?= redhat.com
 RAM_MB ?= 16384
 CPU_CORE ?= 8
 DISK_GB ?= 130
 AGENT_CONFIG ?= agent-config.yaml
+AGENT_CONFIG_RENDER ?= 0
 
 INSTALL_CONFIG_TEMPLATE = $(SNO_DIR)/install-config.yaml.template
 INSTALL_CONFIG = $(SNO_DIR)/install-config.yaml
@@ -59,7 +67,7 @@ NET_NAME ?= test-net
 NET_UUID ?= a29bce40-ce15-43c8-9142-fd0a3cc37f9a
 NET_BRIDGE_NAME ?= tt0
 NET_MAC ?= 52:54:00:e0:8d:fe
-NET_PREFIX ?= $(shell echo $(MACHINE_NETWORK) | cut -d . -f 1-3)
+NET_PREFIX ?= $(shell echo $(MACHINE_NETWORK_V4) | cut -d . -f 1-3)
 VM_NAME ?= sno1
 VOL_NAME = $(VM_NAME).qcow2
 POOL ?= default
@@ -71,9 +79,12 @@ SSH_FLAGS = -o IdentityFile=$(SSH_KEY_PRIV_PATH) \
  			-o UserKnownHostsFile=/dev/null \
  			-o StrictHostKeyChecking=no
 
-HOST_IP ?= 192.168.126.10
+HOST_IP_V4 ?= 192.168.126.10
+HOST_IP_V6 ?= fd00:0:0:126::10
 HOST_MAC ?= 52:54:00:ee:42:e1
-SSH_HOST = core@$(HOST_IP)
+HOST_IFNAME ?= ens3
+HOST_IP_PRIMARY = $(if $(filter v6 v6v4,$(IP_STACK)),$(HOST_IP_V6),$(HOST_IP_V4))
+SSH_HOST = core@$(if $(findstring :,$(HOST_IP_PRIMARY)),[$(HOST_IP_PRIMARY)],$(HOST_IP_PRIMARY))
 
 $(SSH_KEY_PRIV_PATH):
 	@echo "No private key $@ found, generating a private-public pair"
@@ -123,32 +134,44 @@ destroy-libvirt-net:
 	$(SNO_DIR)/virt-delete-net.sh || true
 
 # Render the install config from the template with the correct pull secret and SSH key
-$(INSTALL_CONFIG): $(INSTALL_CONFIG_TEMPLATE) checkenv $(SSH_KEY_PUB_PATH)
-	sed -e 's|YOUR_PULL_SECRET|$(PULL_SECRET)|' \
-	    -e 's|YOUR_SSH_KEY|$(shell cat $(SSH_KEY_PUB_PATH))|' \
-	    -e 's|INSTALLATION_DISK|$(INSTALLATION_DISK)|' \
-	    -e 's|CLUSTER_NAME|$(CLUSTER_NAME)|' \
-	    -e 's|BASE_DOMAIN|$(BASE_DOMAIN)|' \
-	    -e 's|CLUSTER_NETWORK|$(CLUSTER_NETWORK)|' \
-	    -e 's|MACHINE_NETWORK|$(MACHINE_NETWORK)|' \
-	    -e 's|CLUSTER_SVC_NETWORK|$(CLUSTER_SVC_NETWORK)|' \
-	    $(INSTALL_CONFIG_TEMPLATE) > $(INSTALL_CONFIG)
+$(INSTALL_CONFIG): $(INSTALL_CONFIG_TEMPLATE) checkenv $(SSH_KEY_PUB_PATH) registry-config.json
+	$(info Generating $(INSTALL_CONFIG))
+	@IP_STACK=$(IP_STACK) \
+	MACHINE_NETWORK_V4=$(MACHINE_NETWORK_V4) \
+	MACHINE_NETWORK_V6=$(MACHINE_NETWORK_V6) \
+	CLUSTER_NETWORK_V4=$(CLUSTER_NETWORK_V4) \
+	CLUSTER_NETWORK_V6=$(CLUSTER_NETWORK_V6) \
+	CLUSTER_SVC_NETWORK_V4=$(CLUSTER_SVC_NETWORK_V4) \
+	CLUSTER_SVC_NETWORK_V6=$(CLUSTER_SVC_NETWORK_V6) \
+	CLUSTER_NETWORK_HOSTPREFIX_V4=$(CLUSTER_NETWORK_HOSTPREFIX_V4) \
+	CLUSTER_NETWORK_HOSTPREFIX_V6=$(CLUSTER_NETWORK_HOSTPREFIX_V6) \
+	INSTALLATION_DISK=$(INSTALLATION_DISK) \
+	CLUSTER_NAME=$(CLUSTER_NAME) \
+	BASE_DOMAIN=$(BASE_DOMAIN) \
+	python3 $(SNO_DIR)/render-install-config.py \
+		--pull-secret-file registry-config.json \
+		--ssh-key-file $(SSH_KEY_PUB_PATH) \
+		--output $(INSTALL_CONFIG)
 
 # Render the libvirt net config file with the network name and host IP
 $(NET_CONFIG): $(NET_CONFIG_TEMPLATE)
-	sed -e 's/REPLACE_NET_NAME/$(NET_NAME)/' \
-	    -e 's|REPLACE_NET_UUID|$(NET_UUID)|' \
-	    -e 's/REPLACE_NET_BRIDGE_NAME/$(NET_BRIDGE_NAME)/' \
-	    -e 's/REPLACE_NET_MAC/$(NET_MAC)/' \
-	    -e 's/REPLACE_NET_PREFIX/$(NET_PREFIX)/g' \
-	    -e 's|BASE_DOMAIN|$(BASE_DOMAIN)|' \
-	    $(NET_CONFIG_TEMPLATE) > $@
+	IP_STACK=$(IP_STACK) \
+	MACHINE_NETWORK_V4=$(MACHINE_NETWORK_V4) \
+	MACHINE_NETWORK_V6=$(MACHINE_NETWORK_V6) \
+	HOST_IP_V6=$(HOST_IP_V6) \
+	NET_NAME=$(NET_NAME) \
+	NET_UUID=$(NET_UUID) \
+	NET_BRIDGE_NAME=$(NET_BRIDGE_NAME) \
+	NET_MAC=$(NET_MAC) \
+	BASE_DOMAIN=$(BASE_DOMAIN) \
+	python3 $(SNO_DIR)/render-net-xml.py --output $@
 
 network: $(NET_CONFIG)
 	NET_NAME=$(NET_NAME) \
 	NET_UUID=$(NET_UUID) \
+	NET_BRIDGE_NAME=$(NET_BRIDGE_NAME) \
 	NET_XML=$(NET_CONFIG) \
-	HOST_IP=$(HOST_IP) \
+	HOST_IP=$(HOST_IP_PRIMARY) \
 	CLUSTER_NAME=$(CLUSTER_NAME) \
 	BASE_DOMAIN=$(BASE_DOMAIN) \
 	$(SNO_DIR)/virt-create-net.sh
@@ -217,7 +240,19 @@ start-iso: $(INSTALLER_ISO_PATH_SNO_IN_LIBVIRT) network
 	$(SNO_DIR)/virt-install-sno-iso-ign.sh
 
 $(AGENT_CONFIG_IN_WORKDIR): $(AGENT_CONFIG) $(INSTALLER_WORKDIR)
-	sudo cp $< $@
+	@if [ "$(AGENT_CONFIG_RENDER)" = "1" ]; then \
+		IP_STACK=$(IP_STACK) \
+		MACHINE_NETWORK_V4=$(MACHINE_NETWORK_V4) \
+		MACHINE_NETWORK_V6=$(MACHINE_NETWORK_V6) \
+		HOST_IP_V4=$(HOST_IP_V4) \
+		HOST_IP_V6=$(HOST_IP_V6) \
+		HOST_NAME=$(VM_NAME) \
+		HOST_MAC=$(HOST_MAC) \
+		HOST_IFNAME=$(HOST_IFNAME) \
+		python3 $(SNO_DIR)/render-agent-config.py --output $@ ; \
+	else \
+		sudo cp $< $@ ; \
+	fi
 
 # Generate an agent based ISO
 $(ABI_ISO_PATH): $(INSTALLER_BIN) $(AGENT_CONFIG_IN_WORKDIR) $(INSTALL_CONFIG_IN_WORKDIR)
@@ -253,15 +288,19 @@ abi-wait-complete: $(INSTALLER_BIN)
 	INSTALLER_WORKDIR=$(INSTALLER_WORKDIR) \
 	$(SNO_DIR)/wait-abi-complete.sh
 
-# Configure dhcp and dns for host
+# Configure dns records for the host (DHCP reservations are optional)
 .PHONY: host-net-config
 host-net-config:
-	HOST_IP=$(HOST_IP) \
+	IP_STACK=$(IP_STACK) \
+	HOST_IP=$(HOST_IP_PRIMARY) \
+	HOST_IP_V4=$(HOST_IP_V4) \
+	HOST_IP_V6=$(HOST_IP_V6) \
 	CLUSTER_NAME=$(CLUSTER_NAME) \
 	BASE_DOMAIN=$(BASE_DOMAIN) \
 	NET_NAME=$(NET_NAME) \
 	HOST_NAME=$(VM_NAME) \
 	HOST_MAC=$(HOST_MAC) \
+	CONFIGURE_DHCP=0 \
 	$(SNO_DIR)/host-net-config.sh
 
 ssh: $(SSH_KEY_PRIV_PATH)
@@ -278,6 +317,6 @@ gather:
 	@echo If this fails, try killing running SSH agent instances. Installer will prefer those \
 over your explicitly provided key file
 	$(INSTALLER_BIN) gather bootstrap \
-	--bootstrap $(HOST_IP) \
-	--master $(HOST_IP) \
+	--bootstrap $(HOST_IP_PRIMARY) \
+	--master $(HOST_IP_PRIMARY) \
 	--key $(SSH_KEY_PRIV_PATH)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Since the manual mode does not have strong dependencies on any platform (i.e., p
 
 - Create a workdir for the installer - `mkdir sno-workdir`
 - Create an `install-config.yaml` in the sno-workdir. An example file can be found in `./install-config.yaml.template`. There are a small number of fields in the template that should be set by hand. Reasonable defaults are given below.
-    * `MACHINE_NETWORK` - the machine network CIDR. A good default is `192.168.126.0/24`.
-    * `CLUSTER_SVC_NETWORK` - the cluster service network CIDR. A good default is `172.30.0.0/16`.
-    * `CLUSTER_NETWORK` - the cluster network CIDR. A good default is `10.128.0.0/14`.
+    * `IP_STACK` - one of `v4`, `v6`, `v4v6` (dual-stack primary v4), `v6v4` (dual-stack primary v6). **In dual-stack, the primary family is always listed first in `install-config.yaml`**.
+    * `MACHINE_NETWORK_V4` - IPv4 machine network CIDR. Default `192.168.126.0/24`.
+    * `MACHINE_NETWORK_V6` - IPv6 machine network CIDR. Default `fd00:0:0:126::/64`.
+    * `CLUSTER_SVC_NETWORK_V4` - IPv4 service network CIDR. Default `172.30.0.0/16`.
+    * `CLUSTER_SVC_NETWORK_V6` - IPv6 service network CIDR. Default `fd02:0:0:0::/112`.
+    * `CLUSTER_NETWORK_V4` - IPv4 cluster network CIDR. Default `10.128.0.0/14`.
+    * `CLUSTER_NETWORK_V6` - IPv6 cluster network CIDR. Default `fd01:0:0:0::/48`.
     * `CLUSTER_NAME` - the cluster name, the default is `test-cluster`.
     * `BASE_DOMAIN` - the cluster base domain, the default is `redhat.com`.
 - Download the ISO to the workdir `./download_live_iso.sh sno-workdir/base.iso`
@@ -105,6 +109,57 @@ Automatic mode using Makefiles, currently supports SNO deployments on two virtua
     - Create a libvirt network & VM.
     - Boot the VM with that ISO.
 - You can now monitor the progress using `abi-wait-complete` or `make ssh` and `journalctl -f -u assisted-service.service` or `kubectl --kubeconfig ./sno-workdir/auth/kubeconfig get clusterversion`.
+
+### Host IP configuration (ABI flow)
+
+For the ABI flow, the host IP is configured via **AgentConfig `hosts[].networkConfig` (nmstate)** (static IP + DNS + default route). This avoids relying on DHCP reservations to force a specific host address.
+
+- The generated `agent-config.yaml` is rendered by `render-agent-config.py` when `AGENT_CONFIG_RENDER=1` (default).
+- `make start-iso-abi` still configures local DNS records (`api.*` / `apps.*`) on the libvirt network gateway so the hostnames resolve correctly.
+- Interface naming differs by platform:
+  - libvirt guests typically use **`ens3`** (default `HOST_IFNAME=ens3`)
+  - bare metal often uses names like **`eno1`** (override via `HOST_IFNAME=eno1`)
+
+## IP stack examples (ABI flow)
+
+IPv4 only:
+
+```bash
+export IP_STACK=v4
+export MACHINE_NETWORK_V4=192.168.126.0/24
+export CLUSTER_NETWORK_V4=10.128.0.0/14
+export CLUSTER_SVC_NETWORK_V4=172.30.0.0/16
+export HOST_IP_V4=192.168.126.10
+export HOST_IFNAME=ens3
+make start-iso-abi
+```
+
+IPv6 only:
+
+```bash
+export IP_STACK=v6
+export MACHINE_NETWORK_V6=fd00:0:0:126::/64
+export HOST_IP_V6=fd00:0:0:126::10
+export HOST_IFNAME=ens3
+make start-iso-abi
+```
+
+Dual-stack, primary IPv4 (v4v6):
+
+```bash
+export IP_STACK=v4v6
+export HOST_IFNAME=ens3
+make start-iso-abi
+```
+
+Dual-stack, primary IPv6 (v6v4):
+
+```bash
+export IP_STACK=v6v4
+export HOST_IP_V6=fd00:0:0:126::10
+export HOST_IFNAME=ens3
+make start-iso-abi
+```
 
 # Other notes
 

--- a/host-net-config.sh
+++ b/host-net-config.sh
@@ -1,27 +1,100 @@
 #!/bin/bash
 
+set -euo pipefail
+
 tmpfile=$(mktemp)
 _cleanup(){
     rm -f $tmpfile
 }
 trap _cleanup exit
 
-# _dnsmasq_add_if_not_exists domain_name ip_address
-_dnsmasq_add_if_not_exists(){
-    grep -vE "^address=/$1/" /etc/NetworkManager/dnsmasq.d/bip.conf > $tmpfile
-    echo "address=/$1/$2" >> $tmpfile
-    sudo tee /etc/NetworkManager/dnsmasq.d/bip.conf < $tmpfile
+CONFIGURE_DHCP="${CONFIGURE_DHCP:-1}"
+
+_stack_order() {
+    # prints families in desired order: ipv4 ipv6 / ipv6 ipv4 / ...
+    case "${IP_STACK:-v4}" in
+        v4) echo "ipv4" ;;
+        v6) echo "ipv6" ;;
+        v4v6) echo "ipv4 ipv6" ;;
+        v6v4) echo "ipv6 ipv4" ;;
+        *) echo "IP_STACK must be one of: v4, v6, v4v6, v6v4" >&2; exit 2 ;;
+    esac
 }
 
-# Update libvirt dhcp configuration
-if sudo virsh net-dumpxml $NET_NAME | grep -q "mac='$HOST_MAC'" ; then
-    action=modify
-else
-    action=add-last
+_want_v4() { [[ "${IP_STACK:-v4}" == "v4" || "${IP_STACK:-v4}" == "v4v6" || "${IP_STACK:-v4}" == "v6v4" ]]; }
+_want_v6() { [[ "${IP_STACK:-v4}" == "v6" || "${IP_STACK:-v4}" == "v4v6" || "${IP_STACK:-v4}" == "v6v4" ]]; }
+
+_dnsmasq_set_addresses() {
+    # _dnsmasq_set_addresses domain_name ip1 [ip2 ...]
+    local domain="$1"; shift
+    sudo mkdir -p /etc/NetworkManager/dnsmasq.d
+    if [ -f /etc/NetworkManager/dnsmasq.d/bip.conf ]; then
+        grep -vE "^address=/${domain}/" /etc/NetworkManager/dnsmasq.d/bip.conf > "$tmpfile" || true
+    else
+        : > "$tmpfile"
+    fi
+    for ip in "$@"; do
+        echo "address=/${domain}/${ip}" >> "$tmpfile"
+    done
+    sudo tee /etc/NetworkManager/dnsmasq.d/bip.conf < "$tmpfile" >/dev/null
+}
+
+_family_index() {
+    # _family_index ipv4|ipv6 -> 0-based index of <ip family='...'> in libvirt network XML
+    local fam="$1"
+    # In dual-stack, the order in net.xml is controlled by IP_STACK (primary first).
+    # We intentionally compute it from virsh output to avoid assumptions.
+    local idx
+    idx="$(sudo virsh net-dumpxml "$NET_NAME" | awk -F"'" '/<ip family=/{print $2}' | nl -ba | awk -v f="$fam" '$2==f {print $1-1; exit}')"
+    if [ -z "$idx" ]; then
+        echo "Could not find <ip family='$fam'> in libvirt network $NET_NAME" >&2
+        exit 1
+    fi
+    echo "$idx"
+}
+
+_net_update_dhcp_host() {
+    # _net_update_dhcp_host ipv4|ipv6 ip_addr
+    local fam="$1"
+    local ip="$2"
+    if [ "$fam" = "ipv6" ]; then
+        # libvirt/dnsmasq does not accept "mac=" for IPv6 static host definitions.
+        # Without a predictable DUID, we can't safely reserve a fixed IPv6 by host identity here.
+        # For single-node libvirt usage, we instead make the IPv6 DHCP range start at HOST_IP_V6
+        # (see render-net-xml.py), so the first lease is deterministic.
+        return 0
+    fi
+    local idx
+    idx="$(_family_index "$fam")"
+    local xml
+    xml="<host mac=\"${HOST_MAC}\" name=\"${HOST_NAME}\" ip=\"${ip}\"/>"
+
+    # If the host entry already exists under this MAC, "modify" works; otherwise fall back to add-last.
+    if sudo virsh net-update "$NET_NAME" modify ip-dhcp-host "$xml" --live --parent-index "$idx" >/dev/null 2>&1; then
+        return 0
+    fi
+    sudo virsh net-update "$NET_NAME" add-last ip-dhcp-host "$xml" --live --parent-index "$idx" >/dev/null
+}
+
+# Defaults for older callers
+: "${HOST_IP_V4:=${HOST_IP:-192.168.126.10}}"
+: "${HOST_IP_V6:=${HOST_IP_V6:-fd00:0:0:126::10}}"
+
+# Optionally update libvirt DHCP configuration for requested families.
+# For ABI, we prefer static host configuration via AgentConfig nmstate, so callers can disable DHCP edits.
+if [ "${CONFIGURE_DHCP}" = "1" ]; then
+    if _want_v4; then
+        _net_update_dhcp_host ipv4 "${HOST_IP_V4}"
+    fi
+    if _want_v6; then
+        _net_update_dhcp_host ipv6 "${HOST_IP_V6}"
+    fi
 fi
-sudo virsh net-update $NET_NAME $action ip-dhcp-host '<host mac="'$HOST_MAC'" name="'$HOST_NAME'" ip="'$HOST_IP'"/>' --live --parent-index 0
 
 # Update dnsmasq configuration
-_dnsmasq_add_if_not_exists api.${CLUSTER_NAME}.${BASE_DOMAIN} ${HOST_IP}
-_dnsmasq_add_if_not_exists apps.${CLUSTER_NAME}.${BASE_DOMAIN} ${HOST_IP}
+dns_ips=()
+if _want_v4; then dns_ips+=("${HOST_IP_V4}"); fi
+if _want_v6; then dns_ips+=("${HOST_IP_V6}"); fi
+_dnsmasq_set_addresses "api.${CLUSTER_NAME}.${BASE_DOMAIN}" "${dns_ips[@]}"
+_dnsmasq_set_addresses "apps.${CLUSTER_NAME}.${BASE_DOMAIN}" "${dns_ips[@]}"
 sudo systemctl reload NetworkManager.service

--- a/render-agent-config.py
+++ b/render-agent-config.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import argparse
+import ipaddress
+import os
+import sys
+
+
+def _optional(env_key: str, default: str) -> str:
+    v = os.environ.get(env_key)
+    return default if v is None or v == "" else v
+
+
+def _optional_fallback(primary_key: str, fallback_key: str, default: str) -> str:
+    v = os.environ.get(primary_key)
+    if v is not None and v != "":
+        return v
+    v2 = os.environ.get(fallback_key)
+    if v2 is not None and v2 != "":
+        return v2
+    return default
+
+
+def _stack_order(ip_stack: str):
+    ip_stack = ip_stack.lower()
+    if ip_stack == "v4":
+        return ["v4"]
+    if ip_stack == "v6":
+        return ["v6"]
+    if ip_stack == "v4v6":
+        return ["v4", "v6"]
+    if ip_stack == "v6v4":
+        return ["v6", "v4"]
+    raise SystemExit("IP_STACK must be one of: v4, v6, v4v6, v6v4")
+
+
+def _gateway_for_cidr(cidr: str) -> str:
+    n = ipaddress.ip_network(cidr, strict=False)
+    # Convention used by libvirt net config in this repo: first usable address is gateway (.1)
+    return str(ipaddress.ip_address(int(n.network_address) + 1))
+
+
+def _prefixlen_for_cidr(cidr: str) -> int:
+    return ipaddress.ip_network(cidr, strict=False).prefixlen
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render agent-config.yaml (rendezvous IP follows primary family)")
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--name", default="sno-cluster")
+    args = ap.parse_args()
+
+    ip_stack = _optional("IP_STACK", "v4")
+    primary = _stack_order(ip_stack)[0]
+
+    host_ip_v4 = _optional_fallback("HOST_IP_V4", "HOST_IP", "192.168.126.10")
+    host_ip_v6 = _optional("HOST_IP_V6", "fd00:0:0:126::10")
+    rendezvous_ip = host_ip_v4 if primary == "v4" else host_ip_v6
+
+    machine_v4 = _optional_fallback("MACHINE_NETWORK_V4", "MACHINE_NETWORK", "192.168.126.0/24")
+    machine_v6 = _optional("MACHINE_NETWORK_V6", "fd00:0:0:126::/64")
+
+    gw_v4 = _optional("GATEWAY_V4", _gateway_for_cidr(machine_v4))
+    gw_v6 = _optional("GATEWAY_V6", _gateway_for_cidr(machine_v6))
+    dns_v4 = _optional("DNS_SERVER_V4", gw_v4)
+    dns_v6 = _optional("DNS_SERVER_V6", gw_v6)
+
+    host_name = _optional("HOST_NAME", "master-0")
+    host_mac = _optional("HOST_MAC", "52:54:00:ee:42:e1")
+    host_ifname = _optional("HOST_IFNAME", "enp1s0")
+
+    want_v4 = ip_stack.lower() in ("v4", "v4v6", "v6v4")
+    want_v6 = ip_stack.lower() in ("v6", "v4v6", "v6v4")
+    v4_prefix = _prefixlen_for_cidr(machine_v4)
+    v6_prefix = _prefixlen_for_cidr(machine_v6)
+
+    dns_servers = []
+    if want_v4:
+        dns_servers.append(dns_v4)
+    if want_v6:
+        dns_servers.append(dns_v6)
+    dns_block = "\n".join([f"              - {s}" for s in dns_servers]) if dns_servers else "              - 8.8.8.8"
+
+    routes_lines = []
+    if want_v4:
+        routes_lines.extend(
+            [
+                "            - destination: 0.0.0.0/0",
+                f"              next-hop-address: {gw_v4}",
+                f"              next-hop-interface: {host_ifname}",
+                "              table-id: 254",
+            ]
+        )
+    if want_v6:
+        routes_lines.extend(
+            [
+                "            - destination: ::/0",
+                f"              next-hop-address: {gw_v6}",
+                f"              next-hop-interface: {host_ifname}",
+                "              table-id: 254",
+            ]
+        )
+
+    iface_lines = [
+        f"        - name: {host_ifname}",
+        "          type: ethernet",
+        "          state: up",
+        f"          mac-address: {host_mac}",
+    ]
+    if want_v4:
+        iface_lines.extend(
+            [
+                "          ipv4:",
+                "            enabled: true",
+                "            address:",
+                f"              - ip: {host_ip_v4}",
+                f"                prefix-length: {v4_prefix}",
+                "            dhcp: false",
+            ]
+        )
+    else:
+        iface_lines.extend(["          ipv4:", "            enabled: false"])
+    if want_v6:
+        iface_lines.extend(
+            [
+                "          ipv6:",
+                "            enabled: true",
+                "            address:",
+                f"              - ip: {host_ip_v6}",
+                f"                prefix-length: {v6_prefix}",
+                "            dhcp: false",
+            ]
+        )
+    else:
+        iface_lines.extend(["          ipv6:", "            enabled: false"])
+
+    content = "\n".join(
+        [
+            "apiVersion: v1alpha1",
+            "kind: AgentConfig",
+            "metadata:",
+            f"  name: {args.name}",
+            f"rendezvousIP: {rendezvous_ip}",
+            "hosts:",
+            f"  - hostname: {host_name}",
+            "    interfaces:",
+            f"      - name: {host_ifname}",
+            f"        macAddress: {host_mac}",
+            "    networkConfig:",
+            "      interfaces:",
+            *iface_lines,
+            "      dns-resolver:",
+            "        config:",
+            "          server:",
+            *dns_block.splitlines(),
+            "      routes:",
+            "        config:",
+            *routes_lines,
+            "",
+        ]
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(content)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/render-install-config.py
+++ b/render-install-config.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+
+
+def _require(env_key: str) -> str:
+    v = os.environ.get(env_key)
+    if v is None or v == "":
+        raise SystemExit(f"Missing required env var: {env_key}")
+    return v
+
+
+def _optional(env_key: str, default: str) -> str:
+    v = os.environ.get(env_key)
+    return default if v is None or v == "" else v
+
+
+def _optional_fallback(primary_key: str, fallback_key: str, default: str) -> str:
+    v = os.environ.get(primary_key)
+    if v is not None and v != "":
+        return v
+    v2 = os.environ.get(fallback_key)
+    if v2 is not None and v2 != "":
+        return v2
+    return default
+
+
+def _read_file(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _indent_block(s: str, spaces: int) -> str:
+    prefix = " " * spaces
+    s = s.rstrip("\n")
+    if not s:
+        return prefix
+    return "\n".join(prefix + line for line in s.splitlines())
+
+
+def _stack_order(ip_stack: str):
+    ip_stack = ip_stack.lower()
+    if ip_stack == "v4":
+        return ["v4"]
+    if ip_stack == "v6":
+        return ["v6"]
+    if ip_stack == "v4v6":
+        return ["v4", "v6"]
+    if ip_stack == "v6v4":
+        return ["v6", "v4"]
+    raise SystemExit("IP_STACK must be one of: v4, v6, v4v6, v6v4")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render install-config.yaml for SNO ABI/BiP")
+    ap.add_argument("--pull-secret-file", required=True)
+    ap.add_argument("--ssh-key-file", required=True)
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    ip_stack = _optional("IP_STACK", "v4")
+    order = _stack_order(ip_stack)
+
+    cluster_name = _require("CLUSTER_NAME")
+    base_domain = _require("BASE_DOMAIN")
+    installation_disk = _require("INSTALLATION_DISK")
+
+    # Backward-compatible v4 env keys (existing Makefile variables)
+    machine_v4 = _optional_fallback("MACHINE_NETWORK_V4", "MACHINE_NETWORK", "192.168.126.0/24")
+    cluster_v4 = _optional_fallback("CLUSTER_NETWORK_V4", "CLUSTER_NETWORK", "10.128.0.0/14")
+    svc_v4 = _optional_fallback("CLUSTER_SVC_NETWORK_V4", "CLUSTER_SVC_NETWORK", "172.30.0.0/16")
+    hostprefix_v4 = int(_optional_fallback("CLUSTER_NETWORK_HOSTPREFIX_V4", "CLUSTER_NETWORK_HOSTPREFIX", "23"))
+
+    # New v6 env keys
+    machine_v6 = _optional("MACHINE_NETWORK_V6", "fd00:0:0:126::/64")
+    cluster_v6 = _optional("CLUSTER_NETWORK_V6", "fd01:0:0:0::/48")
+    svc_v6 = _optional("CLUSTER_SVC_NETWORK_V6", "fd02:0:0:0::/112")
+    hostprefix_v6 = int(_optional("CLUSTER_NETWORK_HOSTPREFIX_V6", "64"))
+
+    pull_secret_raw = _read_file(args.pull_secret_file).strip()
+    # Validate it is JSON and normalize to compact string; install-config wants a string.
+    try:
+        pull_secret_compact = json.dumps(json.loads(pull_secret_raw), separators=(",", ":"))
+    except Exception as e:
+        raise SystemExit(f"Invalid JSON in pull-secret file {args.pull_secret_file}: {e}")
+
+    ssh_key = _read_file(args.ssh_key_file).strip()
+
+    def machine_cidrs():
+        out = []
+        for fam in order:
+            out.append(machine_v4 if fam == "v4" else machine_v6)
+        return out
+
+    def service_cidrs():
+        out = []
+        for fam in order:
+            out.append(svc_v4 if fam == "v4" else svc_v6)
+        return out
+
+    def cluster_entries():
+        out = []
+        for fam in order:
+            if fam == "v4":
+                out.append((cluster_v4, hostprefix_v4))
+            else:
+                out.append((cluster_v6, hostprefix_v6))
+        return out
+
+    lines = []
+    lines.append("apiVersion: v1")
+    lines.append(f"baseDomain: {base_domain}")
+    lines.append("compute:")
+    lines.append("- architecture: amd64")
+    lines.append("  hyperthreading: Enabled")
+    lines.append("  name: worker")
+    lines.append("  platform: {}")
+    lines.append("  replicas: 0")
+    lines.append("controlPlane:")
+    lines.append("  architecture: amd64")
+    lines.append("  hyperthreading: Enabled")
+    lines.append("  name: master")
+    lines.append("  platform: {}")
+    lines.append("  replicas: 1")
+    lines.append("metadata:")
+    lines.append("  creationTimestamp: null")
+    lines.append(f"  name: {cluster_name}")
+    lines.append("networking:")
+    lines.append("  clusterNetwork:")
+    for cidr, hp in cluster_entries():
+        lines.append(f"  - cidr: {cidr}")
+        lines.append(f"    hostPrefix: {hp}")
+    lines.append("  machineNetwork:")
+    for cidr in machine_cidrs():
+        lines.append(f"  - cidr: {cidr}")
+    lines.append("  networkType: OVNKubernetes")
+    lines.append("  serviceNetwork:")
+    for cidr in service_cidrs():
+        lines.append(f"  - {cidr}")
+    lines.append("platform:")
+    lines.append("  none: {}")
+    lines.append("BootstrapInPlace:")
+    lines.append(f"  InstallationDisk: {installation_disk}")
+    lines.append("publish: External")
+    lines.append("pullSecret: |")
+    lines.append(_indent_block(pull_secret_compact, 8))
+    lines.append("sshKey: |")
+    lines.append(_indent_block(ssh_key, 8))
+    lines.append("")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/render-net-xml.py
+++ b/render-net-xml.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import argparse
+import ipaddress
+import os
+import sys
+from typing import Optional
+
+
+def _optional(env_key: str, default: str) -> str:
+    v = os.environ.get(env_key)
+    return default if v is None or v == "" else v
+
+
+def _optional_fallback(primary_key: str, fallback_key: str, default: str) -> str:
+    v = os.environ.get(primary_key)
+    if v is not None and v != "":
+        return v
+    v2 = os.environ.get(fallback_key)
+    if v2 is not None and v2 != "":
+        return v2
+    return default
+
+
+def _stack_order(ip_stack: str):
+    ip_stack = ip_stack.lower()
+    if ip_stack == "v4":
+        return ["v4"]
+    if ip_stack == "v6":
+        return ["v6"]
+    if ip_stack == "v4v6":
+        return ["v4", "v6"]
+    if ip_stack == "v6v4":
+        return ["v6", "v4"]
+    raise SystemExit("IP_STACK must be one of: v4, v6, v4v6, v6v4")
+
+
+def _render_ipv4_block(cidr: str) -> str:
+    n = ipaddress.IPv4Network(cidr, strict=False)
+    # Convention used by the old template: .1 gateway, .2-.254 DHCP
+    gw = str(ipaddress.IPv4Address(int(n.network_address) + 1))
+    dhcp_start = str(ipaddress.IPv4Address(int(n.network_address) + 2))
+    dhcp_end = str(ipaddress.IPv4Address(int(n.broadcast_address) - 1))
+    return "\n".join(
+        [
+            f"  <ip family='ipv4' address='{gw}' prefix='{n.prefixlen}'>",
+            "    <dhcp>",
+            f"      <range start='{dhcp_start}' end='{dhcp_end}'/>",
+            "    </dhcp>",
+            "  </ip>",
+        ]
+    )
+
+
+def _render_ipv6_block(cidr: str, dhcp_start_preferred: Optional[str]) -> str:
+    n = ipaddress.IPv6Network(cidr, strict=False)
+    # Use first usable addresses as gw and DHCP range. Keep range modest.
+    gw = str(ipaddress.IPv6Address(int(n.network_address) + 1))
+    dhcp_start = str(ipaddress.IPv6Address(int(n.network_address) + 2))
+    if dhcp_start_preferred:
+        try:
+            p = ipaddress.IPv6Address(dhcp_start_preferred)
+            if p in n:
+                dhcp_start = str(p)
+        except Exception:
+            # ignore invalid preferred address
+            pass
+    # End at +0x1000 by default, but never exceed last address
+    dhcp_end_int = min(int(ipaddress.IPv6Address(dhcp_start)) + 0x1000, int(n.network_address) + (n.num_addresses - 2))
+    dhcp_end = str(ipaddress.IPv6Address(dhcp_end_int))
+    return "\n".join(
+        [
+            f"  <ip family='ipv6' address='{gw}' prefix='{n.prefixlen}'>",
+            "    <dhcp>",
+            f"      <range start='{dhcp_start}' end='{dhcp_end}'/>",
+            "    </dhcp>",
+            "  </ip>",
+        ]
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render libvirt net XML for IPv4/IPv6/dual-stack")
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+
+    ip_stack = _optional("IP_STACK", "v4")
+    order = _stack_order(ip_stack)
+
+    net_name = _optional("NET_NAME", "test-net")
+    net_uuid = _optional("NET_UUID", "a29bce40-ce15-43c8-9142-fd0a3cc37f9a")
+    bridge = _optional("NET_BRIDGE_NAME", "tt0")
+    mac = _optional("NET_MAC", "52:54:00:e0:8d:fe")
+    base_domain = _optional("BASE_DOMAIN", "redhat.com")
+
+    machine_v4 = _optional_fallback("MACHINE_NETWORK_V4", "MACHINE_NETWORK", "192.168.126.0/24")
+    machine_v6 = _optional("MACHINE_NETWORK_V6", "fd00:0:0:126::/64")
+    host_ip_v6 = _optional("HOST_IP_V6", "fd00:0:0:126::10")
+
+    ip_blocks = []
+    for fam in order:
+        if fam == "v4":
+            ip_blocks.append(_render_ipv4_block(machine_v4))
+        else:
+            ip_blocks.append(_render_ipv6_block(machine_v6, host_ip_v6))
+
+    content = "\n".join(
+        [
+            "<network>",
+            f"  <name>{net_name}</name>",
+            f"  <uuid>{net_uuid}</uuid>",
+            "  <forward mode='nat'/>",
+            f"  <bridge name='{bridge}' stp='on' delay='0'/>",
+            "  <mtu size='1500'/>",
+            f"  <mac address='{mac}'/>",
+            f"  <domain name='{base_domain}' localOnly='yes'/>",
+            "  <dns enable='yes'/>",
+            *ip_blocks,
+            "</network>",
+            "",
+        ]
+    )
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.write(content)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+

--- a/virt-create-net.sh
+++ b/virt-create-net.sh
@@ -30,16 +30,122 @@ if [ -t 1 ]; then
     fi
 fi
 
+set -euo pipefail
+
+if [ -z "${NET_NAME:-}" ]; then
+    echo "Please set NET_NAME"
+    exit 1
+fi
+
 if [ -z ${NET_XML+x} ]; then
     echo "Please set NET_XML"
     exit 1
 fi
 
+if [ -z "${NET_UUID:-}" ]; then
+    echo "Please set NET_UUID"
+    exit 1
+fi
+
+_xml_bridge_name() {
+python3 - "$1" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+path = sys.argv[1]
+root = ET.parse(path).getroot()
+bridge = root.find("bridge")
+print("" if bridge is None else bridge.attrib.get("name", ""))
+PY
+}
+
+_xml_uuid() {
+python3 - "$1" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+path = sys.argv[1]
+root = ET.parse(path).getroot()
+uuid = root.find("uuid")
+print("" if uuid is None or uuid.text is None else uuid.text.strip())
+PY
+}
+
+_virsh_net_dumpxml() {
+    sudo virsh net-dumpxml "$1" 2>/dev/null || true
+}
+
+_virsh_bridge_name() {
+python3 - <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+xml = sys.stdin.read()
+if not xml.strip():
+    print("")
+    raise SystemExit(0)
+root = ET.fromstring(xml)
+bridge = root.find("bridge")
+print("" if bridge is None else bridge.attrib.get("name", ""))
+PY
+}
+
+_virsh_uuid() {
+python3 - <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+xml = sys.stdin.read()
+if not xml.strip():
+    print("")
+    raise SystemExit(0)
+root = ET.fromstring(xml)
+uuid = root.find("uuid")
+print("" if uuid is None or uuid.text is None else uuid.text.strip())
+PY
+}
+
+# If NET_BRIDGE_NAME is provided, validate it matches the XML we are about to define.
+if [ -n "${NET_BRIDGE_NAME:-}" ]; then
+    xml_bridge="$(_xml_bridge_name "${NET_XML}")"
+    if [ -z "${xml_bridge}" ]; then
+        echo "Error: could not determine <bridge name='...'> from ${NET_XML}"
+        exit 1
+    fi
+    if [ "${xml_bridge}" != "${NET_BRIDGE_NAME}" ]; then
+        echo "Error: NET_BRIDGE_NAME='${NET_BRIDGE_NAME}' but ${NET_XML} contains bridge '${xml_bridge}'"
+        echo "Hint: this usually means you're defining a stale/incorrect net.xml from a different directory."
+        exit 1
+    fi
+fi
+
+# If a network with the same name exists but has a different UUID, replace it.
+existing_uuid="$(_virsh_net_dumpxml "${NET_NAME}" | _virsh_uuid)"
+if [ -n "${existing_uuid}" ] && [ "${existing_uuid}" != "${NET_UUID}" ]; then
+    echo "Network '${NET_NAME}' already exists with UUID '${existing_uuid}' (expected '${NET_UUID}'), replacing it"
+    sudo virsh net-destroy "${NET_NAME}" >/dev/null 2>&1 || true
+    sudo virsh net-undefine "${NET_NAME}" >/dev/null 2>&1 || true
+fi
+
 # Only create network if it does not exist
 if ! sudo virsh net-dumpxml $NET_NAME | grep -q "<uuid>$NET_UUID</uuid>"; then
     sudo virsh net-define "${NET_XML}"
+    # Sanity-check what libvirt stored (helps catch "stale XML" or unexpected mutation).
+    stored_xml="$(_virsh_net_dumpxml "${NET_NAME}")"
+    stored_bridge="$(printf '%s' "${stored_xml}" | _virsh_bridge_name)"
+    if [ -n "${NET_BRIDGE_NAME:-}" ] && [ -n "${stored_bridge}" ] && [ "${stored_bridge}" != "${NET_BRIDGE_NAME}" ]; then
+        echo "Error: after net-define, libvirt stored bridge '${stored_bridge}' but NET_BRIDGE_NAME='${NET_BRIDGE_NAME}'"
+        echo "This indicates the network definition does not match the intended XML."
+        exit 1
+    fi
     sudo virsh net-autostart $NET_NAME
-    sudo virsh net-start $NET_NAME
+    if ! sudo virsh net-start $NET_NAME; then
+        echo "Error: failed to start libvirt network '${NET_NAME}' from ${NET_XML}"
+        if [ -n "${NET_BRIDGE_NAME:-}" ]; then
+            echo "Bridge requested: ${NET_BRIDGE_NAME}"
+        else
+            echo "Bridge in XML: $(_xml_bridge_name "${NET_XML}")"
+        fi
+        echo "Bridge in libvirt definition: ${stored_bridge:-unknown}"
+        echo "Tip: if you see 'already in use by interface <X>', pick a unique NET_BRIDGE_NAME not used on the host."
+        exit 1
+    fi
 fi
 
 echo -e "[main]\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/bip.conf

--- a/virt-delete-net.sh
+++ b/virt-delete-net.sh
@@ -5,5 +5,5 @@ if [ -z ${NET_NAME+x} ]; then
 	exit 1
 fi
 
-sudo virsh net-undefine "$NET_NAME"
-sudo virsh net-destroy "$NET_NAME"
+sudo virsh net-destroy "$NET_NAME" >/dev/null 2>&1 || true
+sudo virsh net-undefine "$NET_NAME" >/dev/null 2>&1 || true


### PR DESCRIPTION
It will enable DS clusters in the following flows:

- IBU
- IBI
- IPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-family IPv4/IPv6 network settings and configurable primary IP family
  * Optional rendering pipeline for agent, install, and network configs to support multi-network layouts
  * Safer libvirt network creation with validation and improved deletion handling

* **Bug Fixes / Reliability**
  * More robust DHCP/DNS updates and consistent host-IP handling across stacks
  * Better error handling and clearer startup diagnostics

* **Documentation**
  * Expanded IPv4/IPv6/dual-stack ABI examples and usage guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->